### PR TITLE
recommend referring directly to constrained BRSKI, 

### DIFF
--- a/draft-ietf-cose-x509.xml
+++ b/draft-ietf-cose-x509.xml
@@ -47,7 +47,7 @@
       </t>
       <t>
         <!-- JLS - Robin did you really mean to just refer to version -00? -->
-	In some of these cases, a constrained device is being deployed in the context of an existing X.509 PKI: for example, in the 6TiSCH environment, <xref target="I-D.richardson-enrollment-roadmap"/> describes a device enrollment solution that relies on the presence of a factory-installed certificate on the device.
+	In some of these cases, a constrained device is being deployed in the context of an existing X.509 PKI: for example, <xref target="I-D.ietf-anima-constrained-voucher" /> describes a device enrollment solution that relies on the presence of a factory-installed certificate on the device.
 	The <xref target="I-D.ietf-lake-edhoc"/> draft was also written with the idea that long term certificates could be used to provide for authentication of devices, and uses them to establish session keys.
 	Another possible scenario is the use of COSE as the basis for a secure messaging application.
         This scenario assumes the presence of long term keys and a central authentication authority.
@@ -445,7 +445,7 @@ COSE_CertHash = [ hashAlg: (int / tstr), hashValue: bstr ]
         <xi:include href="bibxml/reference.RFC.8610.xml"/>
         <!-- <xi:include href="bibxml/reference.I-D.ietf-acme-acme.xml"/> -->
         <xi:include href="bibxml/reference.RFC.3986.xml"/>
-        <xi:include href="bibxml3/reference.I-D.richardson-enrollment-roadmap.xml"/>
+        <xi:include href="bibxml3/reference.I-D.ietf-anima-constrained-voucher.xml"/>
       </references>
     </references>
   </back>


### PR DESCRIPTION
as enrollment-roadmap is never gonna get published, and indirection not worth it