### PR TITLE
Clearly state purpose of x5t header

### DIFF
--- a/draft-ietf-cose-x509.xml
+++ b/draft-ietf-cose-x509.xml
@@ -171,7 +171,7 @@ obtained from any of these methods still need to validate it.
         <dt>x5t:</dt>
         <dd>
           <t>
-            This header parameter provides the ability to identify an X.509 certificate by a hash value (a thumbprint).
+            This header parameter identifies the end-entity X.509 certificate by a hash value (a thumbprint).
             The 'x5t' header parameter is represented as an array of two elements.
             The first element is an algorithm identifier which is an integer or a string containing the hash algorithm identifier corresponding to either the Value (integer) or Name (string) column of the algorithm registered in the "COSE Algorithms" registry <eref target="https://www.iana.org/assignments/cose/cose.xhtml#algorithms" brackets="none"/>.
             The second element is a binary string containing the hash value computed over the DER encoded certificate.
@@ -180,7 +180,7 @@ obtained from any of these methods still need to validate it.
             As this header parameter does not provide any trust, the header parameter can be in either a protected or unprotected header bucket.
           </t>
           <t>
-           The end-entity certificate MUST be integrity protected by COSE. This can e.g. be done by sending the header parameter in the protected header or including the end-entity certificate in the external_aad. 
+           The identification of the end-entity certificate MUST be integrity protected by COSE. This can be done by sending the header parameter in the protected header or including the end-entity certificate in the external_aad. 
           </t>
 	  <t>
 	  The 'x5t' header parameter can be used alone or together with the 'x5bag', 'x5chain', or 'x5u' header parameters to provide integrity protection of the end-entity certificate. 


### PR DESCRIPTION
Explicitly state the purpose of the x5t header in a way similar and compatible with JWT.

Uses "end-entity" because it occurs elsewhere in the document, but would also be fine using the terminology that JWT uses if it was used consistently in the document.